### PR TITLE
Make sticky positioning also work in Safari.

### DIFF
--- a/chapter3/position-sticky.html
+++ b/chapter3/position-sticky.html
@@ -10,6 +10,7 @@
             width: 200px;
             top: 20px;
             position: sticky;
+            position: -webkit-sticky; /* to make it work in Safari */
             border: 1px solid #d0bfff;
             border-radius: 5px;
             background-color: #e5dbff;


### PR DESCRIPTION
Unfortunately in Safari we have to use the `-webkit-` vendor prefix.